### PR TITLE
Automate Homebrew releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1.7
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          formula-name: ox
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Bump Homebrew formula on a new tag using Github action https://github.com/mislav/bump-homebrew-formula-action.
(in response to https://github.com/curlpipe/ox/pull/37#issuecomment-726805667)