### PR TITLE
Fixed performance some issues with large files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "clap",
  "crossterm",
  "directories",
+ "lazy_static",
  "regex",
  "ron",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ regex = "1.4.2"
 directories = "3.0.1"
 crossterm = "0.18.2"
 term = "0.6.1"
+lazy_static = "1.4.0"
 
 [package.metadata.rpm]
 package = "ox"

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,14 +6,20 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 // For holding general purpose regular expressions
 #[derive(Debug, Clone)]
 pub struct Exp {
-    pub ansi: Regex,
+    pub ansi: &'static Regex,
+}
+
+lazy_static::lazy_static!{
+    static ref ANSI_REGEX: Regex = {
+        Regex::new(r"\u{1b}\[[0-?]*[ -/]*[@-~]").unwrap()
+    };
 }
 
 impl Exp {
     pub fn new() -> Self {
         // Create the regular expressions
         Self {
-            ansi: Regex::new(r"\u{1b}\[[0-?]*[ -/]*[@-~]").unwrap(),
+            ansi: &*ANSI_REGEX, 
         }
     }
     pub fn ansi_len(&self, string: &str) -> usize {


### PR DESCRIPTION
With this change i can now open files up to 1G without overflowing ram. Previously opening a file around 100M in size would overflow swap and ram. While I did add lazy_static as a dependency its not a big deal as both regex and crossterm already include it.

note: files with long lines are still an issue this mainly solves memory consumption of files with many lines
