### PR TITLE
Fixed deleting wide characters

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -331,7 +331,7 @@ impl Editor {
                         let row = self.doc[self.tab].rows[current.y].clone();
                         let chr = row
                             .ext_chars()
-                            .get(current.x.saturating_add(1))
+                            .get(current.x.saturating_sub(1))
                             .map_or(" ", |chr| *chr);
                         let current = Position {
                             x: current.x.saturating_sub(UnicodeWidthStr::width(chr)),


### PR DESCRIPTION
Just a simple fix for deleting wide unicode characters.
Tested on [this](https://github.com/unicode-rs/unicode-width/blob/d0aa541144151c09268878dd781f06011498389a/src/tests.rs#L98).

### Before:
![before](https://user-images.githubusercontent.com/20520951/117477678-96663780-af5e-11eb-9cc4-5750f45bd798.gif)

### After:
![after](https://user-images.githubusercontent.com/20520951/117477698-9d8d4580-af5e-11eb-8c44-ea2316a1ecae.gif)

