### PR TITLE
Use generic `temp_dir()` instead of `/tmp/`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ macro_rules! log {
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open("/tmp/ox.log");
+            .open(std::env::temp_dir().join("ox.log"));
         if let Ok(mut log) = file {
             writeln!(log, "{}: {}", $type, $msg).unwrap();
         } else {


### PR DESCRIPTION
Enables ox to run on windows