### PR TITLE
Add selection - Part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ assets = [
 
 [dependencies]
 alinio = "0.2.1"
-base64 = "0.22.1"
+copypasta-ext = "0.4.4"
 crossterm = "0.27.0"
 jargon-args = "0.2.7"
 kaolinite = { path = "./kaolinite" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ assets = [
 
 [dependencies]
 alinio = "0.2.1"
+base64 = "0.22.1"
 crossterm = "0.27.0"
 jargon-args = "0.2.7"
 kaolinite = { path = "./kaolinite" }

--- a/config/.oxrc
+++ b/config/.oxrc
@@ -14,6 +14,18 @@ event_mapping = {
     ["right"] = function() 
         editor:move_right() 
     end,
+    ["shift_up"] = function() 
+        editor:select_up() 
+    end,
+    ["shift_down"] = function() 
+        editor:select_down() 
+    end,
+    ["shift_left"] = function() 
+        editor:select_left() 
+    end,
+    ["shift_right"] = function() 
+        editor:select_right() 
+    end,
     ["ctrl_up"] = function() 
         editor:move_top() 
     end,
@@ -59,16 +71,13 @@ event_mapping = {
         editor:save_as()
     end,
     ["ctrl_a"] = function()
-        editor:save_all()
+        editor:select_all()
     end,
     ["ctrl_q"] = function()
         editor:quit()
     end,
-    ["shift_left"] = function()
-        editor:previous_tab();
-    end,
-    ["shift_right"] = function()
-        editor:next_tab();
+    ["ctrl_c"] = function()
+        editor:copy()
     end,
     -- Undo & Redo
     ["ctrl_z"] = function()

--- a/config/.oxrc
+++ b/config/.oxrc
@@ -200,6 +200,8 @@ colors.warning_bg = {41, 41, 61}
 colors.error_fg = {255, 100, 100}
 colors.error_bg = {41, 41, 61}
 
+colors.selection_fg = {255, 255, 255}
+colors.selection_bg = {59, 59, 130}
 
 -- Configure Line Numbers --
 line_numbers.enabled = true

--- a/config/.oxrc
+++ b/config/.oxrc
@@ -236,7 +236,7 @@ Shift + <-: Previous Tab
 
 
 -- Configure Mouse Behaviour --
-terminal.mouse_enabled = false
+terminal.mouse_enabled = true
 
 -- Configure Syntax Highlighting Colours --
 syntax:set("string", {39, 222, 145}) -- Strings in various programming languages

--- a/config/.oxrc
+++ b/config/.oxrc
@@ -70,14 +70,21 @@ event_mapping = {
     ["alt_s"] = function()
         editor:save_as()
     end,
-    ["ctrl_a"] = function()
-        editor:select_all()
+    ["alt_a"] = function()
+        editor:save_all()
     end,
     ["ctrl_q"] = function()
         editor:quit()
     end,
+    -- Clipboard Interaction
+    ["ctrl_a"] = function()
+        editor:select_all()
+    end,
     ["ctrl_c"] = function()
         editor:copy()
+    end,
+    ["ctrl_v"] = function()
+        editor:paste()
     end,
     -- Undo & Redo
     ["ctrl_z"] = function()

--- a/config/.oxrc
+++ b/config/.oxrc
@@ -225,8 +225,8 @@ Ctrl + N:   New
 Ctrl + O:   Open          
 Ctrl + Q:   Quit          
 Ctrl + S:   Save          
-Ctrl + W:   Save as       
-Ctrl + A:   Save all      
+Alt  + S:   Save as       
+Alt  + A:   Save all      
 Ctrl + Z:   Undo          
 Ctrl + Y:   Redo          
 Ctrl + F:   Find          

--- a/kaolinite/examples/tabs.rs
+++ b/kaolinite/examples/tabs.rs
@@ -8,7 +8,7 @@ fn main() {
     ).expect("File couldn't be opened");
     // Load viewport
     doc.load_to(10);
-    doc.goto(&Loc { x: 0, y: 0 });
+    doc.move_to(&Loc { x: 0, y: 0 });
     // Find something out of buffer
     println!("{:?}", doc.line(0));
     println!("{:?}", doc.line(1));

--- a/kaolinite/src/document.rs
+++ b/kaolinite/src/document.rs
@@ -4,9 +4,10 @@ use crate::map::{CharMap, form_map};
 use crate::searching::{Searcher, Match};
 use crate::utils::{Loc, Size, get_range, trim, width, tab_boundaries_backward, tab_boundaries_forward};
 use ropey::Rope;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 
 /// A document struct manages a file.
 /// It has tools to read, write and traverse a document.
@@ -29,8 +30,8 @@ pub struct Document {
     pub tab_map: CharMap,
     /// Contains the size of this document for purposes of offset
     pub size: Size,
-    /// Contains where the cursor is within the terminal
-    pub cursor: Loc,
+    /// Contains the cursor data structure
+    pub cursor: Cursor,
     /// Contains the offset (scrolling for longer documents)
     pub offset: Loc,
     /// Keeps track of where the character pointer is
@@ -60,7 +61,7 @@ impl Document {
             tab_map: CharMap::default(),
             loaded_to: 1,
             file_name: None,
-            cursor: Loc::default(),
+            cursor: Cursor::default(),
             offset: Loc::default(),
             size,
             char_ptr: 0,
@@ -88,7 +89,7 @@ impl Document {
             tab_map: CharMap::default(),
             loaded_to: 0,
             file_name: Some(file_name),
-            cursor: Loc::default(),
+            cursor: Cursor::default(),
             offset: Loc::default(),
             size,
             char_ptr: 0,
@@ -146,6 +147,7 @@ impl Document {
             self.event_mgmt.register(ev.clone());
             self.forth(ev)?;
         }
+        self.cancel_selection();
         Ok(())
     }
 
@@ -187,6 +189,10 @@ impl Document {
         }
     }
 
+    pub fn loc_to_file_pos(&self, loc: &Loc) -> usize {
+        self.file.line_to_char(loc.y) + loc.x
+    }
+
     /// Inserts a string into this document.
     /// # Errors
     /// Returns an error if location is out of range.
@@ -194,9 +200,9 @@ impl Document {
         self.out_of_range(loc.x, loc.y)?;
         self.modified = true;
         // Move cursor to location
-        self.goto(loc);
+        self.move_to(loc);
         // Update rope
-        let idx = self.file.line_to_char(loc.y) + loc.x;
+        let idx = self.loc_to_file_pos(loc);
         self.file.insert(idx, st);
         // Update cache
         let line: String = self.file.line(loc.y).chars().collect();
@@ -217,7 +223,7 @@ impl Document {
         self.dbl_map.splice(loc, dbl_start, dbls);
         self.tab_map.splice(loc, tab_start, tabs);
         // Go to end x position
-        self.goto_x(loc.x + st.chars().count());
+        self.move_to_x(loc.x + st.chars().count());
         self.old_cursor = self.char_ptr;
         Ok(())
     }
@@ -257,7 +263,7 @@ impl Document {
         let (mut start, mut end) = get_range(&x, line_start, line_end);
         self.valid_range(start, end, y)?;
         self.modified = true;
-        self.goto(&Loc::at(start, y));
+        self.move_to(&Loc::at(start, y));
         start += line_start;
         end += line_start;
         let removed = self.file.slice(start..end).to_string();
@@ -297,7 +303,7 @@ impl Document {
         self.file.insert(char_idx, &(contents + "\n"));
         self.loaded_to += 1;
         // Goto line
-        self.goto_y(loc);
+        self.move_to_y(loc);
         self.old_cursor = self.char_ptr;
         Ok(())
     }
@@ -322,7 +328,7 @@ impl Document {
         self.file.remove(idx_start..idx_end);
         self.loaded_to = self.loaded_to.saturating_sub(1);
         // Goto line
-        self.goto_y(loc);
+        self.move_to_y(loc);
         self.old_cursor = self.char_ptr;
         Ok(())
     }
@@ -339,7 +345,7 @@ impl Document {
         let rhs: String = line.chars().skip(loc.x).collect();
         self.delete(loc.x.., loc.y)?;
         self.insert_line(loc.y + 1, rhs)?;
-        self.goto(&Loc::at(0, loc.y + 1));
+        self.move_to(&Loc::at(0, loc.y + 1));
         self.old_cursor = self.char_ptr;
         Ok(())
     }
@@ -356,92 +362,107 @@ impl Document {
         let below = self.line(y + 1).ok_or(Error::OutOfRange)?;
         self.delete_line(y + 1)?;
         self.insert(&Loc::at(length, y), &below)?;
-        self.goto(&Loc::at(length, y));
+        self.move_to(&Loc::at(length, y));
         self.old_cursor = self.char_ptr;
         Ok(())
     }
 
+    pub fn cancel_selection(&mut self) {
+        self.cursor.selection_end = self.cursor.loc;
+    }
+
+    /// Move the view down
+    pub fn scroll_down(&mut self) {
+        self.offset.y += 1;
+        self.load_to(self.offset.y + self.size.h);
+    }
+
+    /// Move the view up
+    pub fn scroll_up(&mut self) {
+        self.offset.y = self.offset.y.saturating_sub(1);
+        self.load_to(self.offset.y + self.size.h);
+    }
+
     /// Move the cursor up
     pub fn move_up(&mut self) -> Status {
+        let r = self.select_up();
+        self.cancel_selection();
+        r
+    }
+
+    /// Select with the cursor up
+    pub fn select_up(&mut self) -> Status {
         // Return if already at start of document
         if self.loc().y == 0 {
             return Status::StartOfFile;
         }
-        // Move up one line
-        if self.cursor.y == 0 {
-            self.offset.y -= 1;
-        } else {
-            self.cursor.y -= 1;
-        }
+        self.cursor.loc.y -= 1;
         // Snap to end of line
         self.fix_dangling_cursor();
         // Move back if in the middle of a longer character
         self.fix_split();
         // Update the character pointer
         self.update_char_ptr();
-        self.goto_x(self.old_cursor);
+        self.bring_cursor_in_viewport();
         Status::None
     }
 
     /// Move the cursor down
     pub fn move_down(&mut self) -> Status {
+        let r = self.select_down();
+        self.cancel_selection();
+        r
+    }
+
+    /// Select with the cursor down
+    pub fn select_down(&mut self) -> Status {
         // Return if already on end of document
         if self.len_lines() < self.loc().y + 1 {
             return Status::EndOfFile;
         }
-        // Ensure that line is loaded from buffer
-        self.load_to(self.loc().y + 2);
-        // Move down one line
-        if self.cursor.y == self.size.h.saturating_sub(1) {
-            self.offset.y += 1;
-        } else {
-            self.cursor.y += 1;
-        }
+        self.cursor.loc.y += 1;
         // Snap to end of line
         self.fix_dangling_cursor();
         // Move back if in the middle of a longer character
         self.fix_split();
         // Update the character pointer
         self.update_char_ptr();
-        self.goto_x(self.old_cursor);
-        //panic!("{}", self.old_cursor);
+        self.bring_cursor_in_viewport();
         Status::None
     }
 
     /// Move the cursor left
     pub fn move_left(&mut self) -> Status {
+        let r = self.select_left();
+        self.cancel_selection();
+        r
+    }
+
+    /// Select with the cursor left
+    pub fn select_left(&mut self) -> Status {
         // Return if already at start of line
         if self.loc().x == 0 {
             return Status::StartOfLine;
         }
         // Determine the width of the character to traverse
-        let line = self.line(self.loc().y).unwrap_or_else(|| "".to_string());
-        let boundaries = tab_boundaries_backward(&line, self.tab_width);
-        let width = if boundaries.contains(&self.char_ptr) {
-            // Push the character pointer up
-            self.char_ptr -= self.tab_width.saturating_sub(1);
-            // There are spaces that should be treated as tabs (so should traverse the tab width)
-            self.tab_width
-        } else {
-            // There are no spaces that should be treated as tabs
-            self.width_of(self.loc().y, self.char_ptr.saturating_sub(1))
-        };
+        let width = self.width_of(self.loc().y, self.char_ptr.saturating_sub(1));
         // Move back the correct amount
-        for _ in 0..width {
-            if self.cursor.x == 0 {
-                self.offset.x -= 1;
-            } else {
-                self.cursor.x -= 1;
-            }
-        }
+        self.cursor.loc.x -= width;
         // Update the character pointer
         self.char_ptr -= 1;
-        self.old_cursor = self.char_ptr;
+        self.bring_cursor_in_viewport();
         Status::None
     }
 
     /// Move the cursor right
     pub fn move_right(&mut self) -> Status {
+        let r = self.select_right();
+        self.cancel_selection();
+        r
+    }
+
+    /// Select with the cursor right
+    pub fn select_right(&mut self) -> Status {
         // Return if already on end of line
         let line = self.line(self.loc().y).unwrap_or_else(|| "".to_string());
         let width = width(&line, self.tab_width);
@@ -460,82 +481,70 @@ impl Document {
             self.width_of(self.loc().y, self.char_ptr)
         };
         // Move forward the correct amount
-        for _ in 0..width {
-            if self.cursor.x == self.size.w.saturating_sub(1) {
-                self.offset.x += 1;
-            } else {
-                self.cursor.x += 1;
-            }
-        }
+        self.cursor.loc.x += width;
         // Update the character pointer
         self.char_ptr += 1;
+        self.bring_cursor_in_viewport();
         self.old_cursor = self.char_ptr;
         Status::None
     }
 
     /// Move to the start of the line
     pub fn move_home(&mut self) {
-        self.cursor.x = 0;
-        self.offset.x = 0;
+        self.select_home();
+        self.cancel_selection();
+    }
+
+    /// Select to the start of the line
+    pub fn select_home(&mut self) {
+        self.cursor.loc.x = 0;
         self.char_ptr = 0;
-        self.old_cursor = 0;
+        self.bring_cursor_in_viewport();
     }
 
     /// Move to the end of the line
     pub fn move_end(&mut self) {
+        self.select_end();
+        self.cancel_selection();
+    }
+
+    /// Select to the end of the line
+    pub fn select_end(&mut self) {
         let line = self.line(self.loc().y).unwrap_or_else(|| "".to_string());
         let length = line.chars().count();
-        self.goto_x(length);
-        self.old_cursor = self.char_ptr;
+        self.select_to_x(length);
     }
 
     /// Move to the top of the document
     pub fn move_top(&mut self) {
-        self.goto(&Loc::at(0, 0));
-        self.old_cursor = self.char_ptr;
+        self.move_to(&Loc::at(0, 0));
     }
 
     /// Move to the bottom of the document
     pub fn move_bottom(&mut self) {
         let last = self.len_lines();
-        self.goto(&Loc::at(0, last));
-        self.old_cursor = self.char_ptr;
+        self.move_to(&Loc::at(0, last));
+    }
+
+    /// Select to the top of the document
+    pub fn select_top(&mut self) {
+        self.select_to(&Loc::at(0, 0));
+    }
+
+    /// Select to the bottom of the document
+    pub fn select_bottom(&mut self) {
+        let last = self.len_lines();
+        self.select_to(&Loc::at(0, last));
     }
 
     /// Move up by 1 page
     pub fn move_page_up(&mut self) {
-        // Shift viewport to have current line at top of the document
-        self.offset.y += self.cursor.y;
-        let y = self.cursor.y;
-        self.cursor.y = 0;
-        self.char_ptr = 0;
-        self.cursor.x = 0;
-        self.offset.x = 0;
-        self.old_cursor = 0;
-        // Shift the offset up by 1 page
-        self.offset.y = self.offset.y.saturating_sub(self.size.h + y);
+        self.move_to_y(self.cursor.loc.y.saturating_sub(self.size.h));
     }
 
     /// Move down by 1 page
     pub fn move_page_down(&mut self) {
-        // Shift viewport to have current line at top of document
-        self.offset.y += self.cursor.y;
-        let y = self.cursor.y;
-        self.cursor.y = 0;
-        self.char_ptr = 0;
-        self.cursor.x = 0;
-        self.offset.x = 0;
-        self.old_cursor = 0;
-        // Shift the offset down by 1 page
-        let by = self.size.h.saturating_sub(y);
-        let len = self.len_lines();
-        if self.offset.y + by > len {
-            self.offset.y = len;
-        } else {
-            self.offset.y += by;
-            // Buffer new lines in viewport
-            self.load_to(self.offset.y + self.size.h);
-        }
+        self.move_to_y(self.cursor.loc.y + self.size.h);
     }
 
     /// Moves to the previous word in the document
@@ -551,7 +560,7 @@ impl Document {
             if !same {
                 mtch.loc.x += len;
             }
-            self.goto(&mtch.loc);
+            self.move_to(&mtch.loc);
             if same && self.loc().x != 0 {
                 return self.move_prev_word();
             }
@@ -570,7 +579,7 @@ impl Document {
         let re = format!("(\t| {{{}}}|$|^ +| )", self.tab_width);
         if let Some(mut mtch) = self.next_match(&re, 0) {
             mtch.loc.x += mtch.text.chars().count();
-            self.goto(&mtch.loc);
+            self.move_to(&mtch.loc);
         }
         self.old_cursor = self.char_ptr;
         Status::None
@@ -642,20 +651,32 @@ impl Document {
 
     /// Replace all instances of a regex with another string
     pub fn replace_all(&mut self, target: &str, into: &str) {
-        self.goto(&Loc::at(0, 0));
+        self.move_to(&Loc::at(0, 0));
         while let Some(mtch) = self.next_match(target, 1) {
             drop(self.replace(mtch.loc, &mtch.text, into));
         }
     }
 
     /// Function to go to a specific position
-    pub fn goto(&mut self, loc: &Loc) {
-        self.goto_y(loc.y);
-        self.goto_x(loc.x);
+    pub fn move_to(&mut self, loc: &Loc) {
+        self.select_to(loc);
+        self.cancel_selection();
+    }
+
+    /// Function to go to a specific position
+    pub fn select_to(&mut self, loc: &Loc) {
+        self.select_to_y(loc.y);
+        self.select_to_x(loc.x);
     }
 
     /// Function to go to a specific x position
-    pub fn goto_x(&mut self, x: usize) {
+    pub fn move_to_x(&mut self, x: usize) {
+        self.select_to_x(x);
+        self.cancel_selection();
+    }
+
+    /// Function to select to a specific x position
+    pub fn select_to_x(&mut self, x: usize) {
         let line = self.line(self.loc().y).unwrap_or_else(|| "".to_string());
         // If we're already at this x coordinate, just exit
         if self.char_ptr == x {
@@ -663,49 +684,29 @@ impl Document {
         }
         // If the move position is out of bounds, move to the end of the line
         if line.chars().count() < x {
-            let line = self.line(self.loc().y).unwrap_or_else(|| "".to_string());
-            let length = line.chars().count();
-            self.goto_x(length);
+            self.select_end();
             return;
         }
         // Update char position
         self.char_ptr = x;
         // Calculate display index
         let x = self.display_idx(&Loc::at(x, self.loc().y));
-        let viewport = self.offset.x..self.offset.x + self.size.w;
         // Move cursor
-        if x < self.size.w {
-            // Cursor will be in the viewport if the offset is 0
-            self.offset.x = 0;
-            self.cursor.x = x;
-        } else if viewport.contains(&x) {
-            // If the idx is already in viewport, don't adjust offset
-            self.cursor.x = x - self.offset.x;
-        } else {
-            // Index is outside of viewport
-            self.cursor.x = 0;
-            self.offset.x = x;
-        }
+        self.cursor.loc.x = x;
+        self.bring_cursor_in_viewport();
     }
 
     /// Function to go to a specific y position
-    pub fn goto_y(&mut self, y: usize) {
+    pub fn move_to_y(&mut self, y: usize) {
+        self.select_to_y(y);
+        self.cancel_selection();
+    }    
+
+    /// Function to select to a specific y position
+    pub fn select_to_y(&mut self, y: usize) {
         // Bounds checking
         if self.loc().y != y && y <= self.len_lines() {
-            // Move cursor
-            let viewport = self.offset.y..self.offset.y + self.size.h;
-            if y < self.size.h {
-                // Cursor will be in viewport if the offset is 0
-                self.offset.y = 0;
-                self.cursor.y = y;
-            } else if viewport.contains(&y) {
-                // If the line is in viewport already, only move the cursor
-                self.cursor.y = y - self.offset.y;
-            } else {
-                // Index is outside of viewport
-                self.cursor.y = self.size.h.saturating_sub(1);
-                self.offset.y = y - (self.size.h.saturating_sub(1));
-            }
+            self.cursor.loc.y = y;
         }
         // Snap to end of line
         self.fix_dangling_cursor();
@@ -713,7 +714,24 @@ impl Document {
         self.fix_split();
         // Correct the character pointer
         self.update_char_ptr();
+        self.bring_cursor_in_viewport();
         // Load any lines necessary
+        self.load_to(self.offset.y + self.size.h);
+    }
+
+    pub fn bring_cursor_in_viewport(&mut self) {
+        if self.offset.y > self.cursor.loc.y {
+            self.offset.y = self.cursor.loc.y;
+        }
+        if self.offset.y + self.size.h <= self.cursor.loc.y {
+            self.offset.y = self.cursor.loc.y - self.size.h + 1;
+        }
+        if self.offset.x > self.cursor.loc.x {
+            self.offset.x = self.cursor.loc.x;
+        }
+        if self.offset.x + self.size.w <= self.cursor.loc.x {
+            self.offset.x = self.cursor.loc.x - self.size.w + 1;
+        }
         self.load_to(self.offset.y + self.size.h);
     }
 
@@ -764,10 +782,10 @@ impl Document {
     fn fix_dangling_cursor(&mut self) {
         if let Some(line) = self.line(self.loc().y) {
             if self.loc().x > width(&line, self.tab_width) {
-                self.goto_x(line.chars().count());
+                self.select_to_x(line.chars().count());
             }
         } else {
-            self.move_home();
+            self.select_home();
         }
     }
 
@@ -790,17 +808,11 @@ impl Document {
                 magnitude += x - start;
             }
         }
-        for _ in 0..magnitude {
-            if self.cursor.x == 0 {
-                self.offset.x -= 1;
-            } else {
-                self.cursor.x -= 1;
-            }
-        }
+        self.cursor.loc.x -= magnitude;
     }
 
     /// Load lines in this document up to a specified index.
-    /// This must be called before starting to edit the document as 
+    /// This must be called before starting to edit the document as
     /// this is the function that actually load and processes the text.
     pub fn load_to(&mut self, mut to: usize) {
         // Make sure to doesn't go over the number of lines in the buffer
@@ -894,8 +906,8 @@ impl Document {
     #[must_use]
     pub const fn loc(&self) -> Loc {
         Loc {
-            x: self.cursor.x + self.offset.x,
-            y: self.cursor.y + self.offset.y,
+            x: self.cursor.loc.x,
+            y: self.cursor.loc.y,
         }
     }
 
@@ -904,7 +916,61 @@ impl Document {
     pub const fn char_loc(&self) -> Loc {
         Loc {
             x: self.char_ptr,
-            y: self.cursor.y + self.offset.y,
+            y: self.cursor.loc.y,
         }
     }
+
+    pub fn cursor_loc_in_screen(&self) -> Option<Loc> {
+        if self.cursor.loc.x < self.offset.x {
+            return None;
+        }
+        if self.cursor.loc.y < self.offset.y {
+            return None;
+        }
+        let result = Loc {
+            x: self.cursor.loc.x - self.offset.x,
+            y: self.cursor.loc.y - self.offset.y,
+        };
+        if result.x > self.size.w || result.y > self.size.h {
+            return None;
+        }
+        return Some(result);
+    }
+
+    pub fn is_selection_empty(&self) -> bool {
+        self.cursor.loc == self.cursor.selection_end
+    }
+
+    pub fn selection_loc_bound(&self) -> (Loc, Loc) {
+        let mut left = self.cursor.loc;
+        let mut right = self.cursor.selection_end;
+        if left > right {
+            std::mem::swap(&mut left, &mut right);
+        }
+        (left, right)
+    }
+
+    pub fn is_loc_selected(&self, loc: Loc) -> bool {
+        let (left, right) = self.selection_loc_bound();
+        left <= loc && loc < right 
+    }
+
+    pub fn selection_range(&self) -> Range<usize> {
+        let mut left = self.loc_to_file_pos(&self.cursor.loc);
+        let mut right = self.loc_to_file_pos(&self.cursor.selection_end);
+        if left > right {
+            std::mem::swap(&mut left, &mut right);
+        }
+        left..right
+    }
+
+    pub fn selection_text(&self) -> Cow<'_, str> {
+        self.file.get_byte_slice(self.selection_range()).map(|r| r.into()).unwrap_or_default()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct Cursor {
+    pub loc: Loc,
+    pub selection_end: Loc,
 }

--- a/kaolinite/src/document.rs
+++ b/kaolinite/src/document.rs
@@ -189,6 +189,7 @@ impl Document {
         }
     }
 
+    /// Takes a loc and converts it into a char index for ropey
     pub fn loc_to_file_pos(&self, loc: &Loc) -> usize {
         self.file.line_to_char(loc.y) + loc.x
     }
@@ -367,6 +368,7 @@ impl Document {
         Ok(())
     }
 
+    /// Cancels the current selection
     pub fn cancel_selection(&mut self) {
         self.cursor.selection_end = self.cursor.loc;
     }
@@ -719,6 +721,7 @@ impl Document {
         self.load_to(self.offset.y + self.size.h);
     }
 
+    /// Brings the cursor into the viewport so it can be seen
     pub fn bring_cursor_in_viewport(&mut self) {
         if self.offset.y > self.cursor.loc.y {
             self.offset.y = self.cursor.loc.y;
@@ -920,6 +923,7 @@ impl Document {
         }
     }
 
+    /// If the cursor is within the viewport, this will return where it is relatively
     pub fn cursor_loc_in_screen(&self) -> Option<Loc> {
         if self.cursor.loc.x < self.offset.x {
             return None;
@@ -937,10 +941,12 @@ impl Document {
         return Some(result);
     }
 
+    /// Returns true if there is no active selection and vice versa
     pub fn is_selection_empty(&self) -> bool {
         self.cursor.loc == self.cursor.selection_end
     }
 
+    /// Will return the bounds of the current active selection
     pub fn selection_loc_bound(&self) -> (Loc, Loc) {
         let mut left = self.cursor.loc;
         let mut right = self.cursor.selection_end;
@@ -950,11 +956,13 @@ impl Document {
         (left, right)
     }
 
+    /// Returns true if the provided location is within the current active selection
     pub fn is_loc_selected(&self, loc: Loc) -> bool {
         let (left, right) = self.selection_loc_bound();
         left <= loc && loc < right 
     }
 
+    /// Will return the current active selection as a range over file characters
     pub fn selection_range(&self) -> Range<usize> {
         let mut left = self.loc_to_file_pos(&self.cursor.loc);
         let mut right = self.loc_to_file_pos(&self.cursor.selection_end);
@@ -964,11 +972,13 @@ impl Document {
         left..right
     }
 
+    /// Will return the text contained within the current selection
     pub fn selection_text(&self) -> Cow<'_, str> {
         self.file.get_byte_slice(self.selection_range()).map(|r| r.into()).unwrap_or_default()
     }
 }
 
+/// Defines a cursor's position and any selection it may be covering
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct Cursor {
     pub loc: Loc,

--- a/kaolinite/src/utils.rs
+++ b/kaolinite/src/utils.rs
@@ -10,10 +10,10 @@ macro_rules! regex {
 }
 
 /// Represents a location
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Loc {
-    pub x: usize,
     pub y: usize,
+    pub x: usize,
 }
 
 impl Loc {

--- a/kaolinite/tests/test.rs
+++ b/kaolinite/tests/test.rs
@@ -179,7 +179,7 @@ fn document_moving() {
     }
     assert_eq!(doc1.loc(), Loc { x: 0, y: 1 });
     assert_eq!(doc1.offset.y, 1);
-    doc1.goto_y(8);
+    doc1.move_to_y(8);
     assert_eq!(doc1.loc(), Loc { x: 0, y: 8 });
     assert_eq!(doc1.offset.y, 0);
     doc1.move_right();
@@ -210,12 +210,12 @@ fn document_moving() {
     doc2.move_down();
     assert_eq!(doc2.loc(), Loc { x: 22, y: 1 });
     assert_eq!(doc2.char_loc(), Loc { x: 18, y: 1 });
-    doc2.goto(&Loc { x: 6, y: 1 });
+    doc2.move_to(&Loc { x: 6, y: 1 });
     assert_eq!(doc2.loc(), Loc { x: 7, y: 1 });
     assert_eq!(doc2.char_loc(), Loc { x: 6, y: 1 });
     assert_eq!(doc2.offset.x, 0);
     assert_eq!(doc2.offset.y, 0);
-    doc2.goto(&Loc { x: 6, y: 0 });
+    doc2.move_to(&Loc { x: 6, y: 0 });
     doc2.old_cursor = 5;
     doc2.move_down();
     assert_eq!(doc2.loc(), Loc { x: 5, y: 1 });
@@ -224,7 +224,7 @@ fn document_moving() {
     assert_eq!(doc2.offset.y, 0);
     doc2.move_up();
     doc2.offset.x = 6;
-    doc2.cursor.x = 0;
+    doc2.cursor.loc.x = 0;
     doc2.char_ptr = 6;
     doc2.old_cursor = 5;
     doc2.move_down();
@@ -245,14 +245,14 @@ fn document_moving() {
     doc2.move_left();
     doc2.move_left();
     doc2.move_right();
-    doc2.goto_x(10);
+    doc2.move_to_x(10);
     assert_eq!(doc2.loc(), Loc { x: 10, y: 2 });
     assert_eq!(doc2.char_loc(), Loc { x: 10, y: 2 });
     assert_eq!(doc2.offset.x, 10);
-    doc1.goto(&Loc { x: 3, y: 5 });
+    doc1.move_to(&Loc { x: 3, y: 5 });
     assert_eq!(doc1.char_loc(), Loc { x: 3, y: 5 });
-    doc1.goto_y(15);
-    doc1.goto_y(14);
+    doc1.move_to_y(15);
+    doc1.move_to_y(14);
     assert_eq!(doc1.loc(), Loc { x: 1, y: 14 });
     assert_eq!(doc1.offset.y, 6);
     doc1.move_top();
@@ -261,20 +261,20 @@ fn document_moving() {
     doc1.move_bottom();
     assert_eq!(doc1.loc(), Loc { x: 0, y: 17 });
     assert_eq!(doc1.offset.y, 8);
-    doc3.goto_y(34);
+    doc3.move_to_y(34);
     doc3.move_page_down();
-    assert_eq!(doc3.cursor, Loc { x: 0, y: 0 });
+    assert_eq!(doc3.cursor.loc, Loc { x: 0, y: 0 });
     assert_eq!(doc3.offset.y, 35);
     doc3.move_page_down();
-    assert_eq!(doc3.cursor, Loc { x: 0, y: 0 });
+    assert_eq!(doc3.cursor.loc, Loc { x: 0, y: 0 });
     assert_eq!(doc3.offset.y, 45);
     doc3.move_page_down();
-    assert_eq!(doc3.cursor, Loc { x: 0, y: 0 });
+    assert_eq!(doc3.cursor.loc, Loc { x: 0, y: 0 });
     assert_eq!(doc3.offset.y, 55);
     doc3.move_page_up();
-    assert_eq!(doc3.cursor, Loc { x: 0, y: 0 });
+    assert_eq!(doc3.cursor.loc, Loc { x: 0, y: 0 });
     assert_eq!(doc3.offset.y, 45);
-    doc1.goto_y(4);
+    doc1.move_to_y(4);
     doc1.move_page_down();
     doc1.move_page_down();
     assert_eq!(doc1.loc(), Loc { x: 0, y: 17 });
@@ -306,7 +306,7 @@ fn document_tab() {
     assert_eq!(doc1.tab_map.get(1).unwrap(), &vec![(24, 20)]);
     assert_eq!(doc1.tab_map.get(2).unwrap(), &vec![(0, 0), (15, 10)]);
     // Check moving and cursor position
-    doc1.goto(&Loc::at(0, 0));
+    doc1.move_to(&Loc::at(0, 0));
     doc1.move_right();
     assert_eq!(doc1.loc(), Loc::at(6, 0));
     assert_eq!(doc1.char_ptr, 1);
@@ -318,7 +318,7 @@ fn document_tab() {
     assert_eq!(doc1.loc(), Loc::at(7, 0));
     assert_eq!(doc1.char_ptr, 2);
     // Check tab cursor split
-    doc1.goto(&Loc::at(1, 0));
+    doc1.move_to(&Loc::at(1, 0));
     doc1.old_cursor = 6;
     doc1.move_down();
     doc1.move_left();
@@ -586,7 +586,7 @@ fn word_jumping() {
     assert_eq!(doc1.move_prev_word(), Status::StartOfLine);
     assert_eq!(doc1.char_ptr, 0);
     doc1.move_up();
-    doc1.goto_x(210);
+    doc1.move_to_x(210);
     assert_eq!(doc1.move_next_word(), Status::EndOfLine);
     assert_eq!(doc1.char_ptr, 210);
 }
@@ -608,7 +608,7 @@ fn searching() {
     doc1.move_right();
     assert_eq!(doc1.next_match("hi", 0), Some(Match { loc: Loc::at(1, 0), text: "hi".to_string() }));
     assert_eq!(doc1.next_match("hi", 1), Some(Match { loc: Loc::at(1, 6), text: "hi".to_string() }));
-    doc1.goto(&Loc::at(4, 5));
+    doc1.move_to(&Loc::at(4, 5));
     assert_eq!(doc1.prev_match("ex"), Some(Match { loc: Loc::at(0, 5), text: "ex".to_string() }));
     assert_eq!(doc1.prev_match("^a"), Some(Match { loc: Loc::at(0, 2), text: "a".to_string() }));
     assert_eq!(doc1.prev_match("f(i+)"), Some(Match { loc: Loc::at(1, 4), text: "i".to_string() }));

--- a/src/config.rs
+++ b/src/config.rs
@@ -457,6 +457,9 @@ pub struct Colors {
     pub warning_fg: ConfigColor,
     pub error_bg: ConfigColor,
     pub error_fg: ConfigColor,
+
+    pub selection_fg: ConfigColor,
+    pub selection_bg: ConfigColor,
 }
 
 impl Default for Colors {
@@ -484,6 +487,9 @@ impl Default for Colors {
             warning_fg: ConfigColor::Black,
             error_bg: ConfigColor::Black,
             error_fg: ConfigColor::Black,
+
+            selection_fg: ConfigColor::White,
+            selection_bg: ConfigColor::Blue,
         }
     }
 }
@@ -507,6 +513,8 @@ impl LuaUserData for Colors {
         fields.add_field_method_get("warning_fg", |env, this| Ok(this.warning_fg.to_lua(env)));
         fields.add_field_method_get("info_bg", |env, this| Ok(this.info_bg.to_lua(env)));
         fields.add_field_method_get("info_fg", |env, this| Ok(this.info_fg.to_lua(env)));
+        fields.add_field_method_get("selection_fg", |env, this| Ok(this.selection_fg.to_lua(env)));
+        fields.add_field_method_get("selection_bg", |env, this| Ok(this.selection_bg.to_lua(env)));
         fields.add_field_method_set("editor_bg", |_, this, value| {
             this.editor_bg = ConfigColor::from_lua(value);
             Ok(())
@@ -573,6 +581,14 @@ impl LuaUserData for Colors {
         });
         fields.add_field_method_set("info_fg", |_, this, value| {
             this.info_fg = ConfigColor::from_lua(value);
+            Ok(())
+        });
+        fields.add_field_method_set("selection_fg", |_, this, value| {
+            this.selection_fg = ConfigColor::from_lua(value);
+            Ok(())
+        });
+        fields.add_field_method_set("selection_bg", |_, this, value| {
+            this.selection_bg = ConfigColor::from_lua(value);
             Ok(())
         });
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -889,7 +889,7 @@ impl LuaUserData for Editor {
         // Cursor moving
         methods.add_method_mut("move_to", |_, editor, (x, y): (usize, usize)| {
             let y = y.saturating_sub(1);
-            editor.doc_mut().goto(&Loc{ x, y });
+            editor.doc_mut().move_to(&Loc{ x, y });
             update_highlighter(editor);
             Ok(())
         });
@@ -911,6 +911,39 @@ impl LuaUserData for Editor {
         methods.add_method_mut("move_right", |_, editor, ()| {
             editor.right();
             update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("select_up", |_, editor, ()| {
+            editor.select_up();
+            update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("select_down", |_, editor, ()| {
+            editor.select_down();
+            update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("select_left", |_, editor, ()| {
+            editor.select_left();
+            update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("select_right", |_, editor, ()| {
+            editor.select_right();
+            update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("select_all", |_, editor, ()| {
+            editor.select_all();
+            update_highlighter(editor);
+            Ok(())
+        });
+        methods.add_method_mut("copy", |_, editor, ()| {
+            if let Err(err) = editor.copy() {
+                editor.feedback = Feedback::Error(err.to_string());
+            } else {
+                editor.feedback = Feedback::Info("Text copied to clipboard".to_owned());
+            }
             Ok(())
         });
         methods.add_method_mut("move_home", |_, editor, ()| {
@@ -956,24 +989,24 @@ impl LuaUserData for Editor {
         methods.add_method_mut("insert_at", |_, editor, (text, x, y): (String, usize, usize)| {
             let y = y.saturating_sub(1);
             let location = editor.doc_mut().char_loc();
-            editor.doc_mut().goto(&Loc { x, y });
+            editor.doc_mut().move_to(&Loc { x, y });
             for ch in text.chars() {
                 if let Err(err) = editor.character(ch) {
                     editor.feedback = Feedback::Error(err.to_string());
                 }
             }
-            editor.doc_mut().goto(&location);
+            editor.doc_mut().move_to(&location);
             update_highlighter(editor);
             Ok(())
         });
         methods.add_method_mut("remove_at", |_, editor, (x, y): (usize, usize)| {
             let y = y.saturating_sub(1);
             let location = editor.doc_mut().char_loc();
-            editor.doc_mut().goto(&Loc { x, y });
+            editor.doc_mut().move_to(&Loc { x, y });
             if let Err(err) = editor.delete() {
                 editor.feedback = Feedback::Error(err.to_string());
             }
-            editor.doc_mut().goto(&location);
+            editor.doc_mut().move_to(&location);
             update_highlighter(editor);
             Ok(())
         });
@@ -981,7 +1014,7 @@ impl LuaUserData for Editor {
             let y = y.saturating_sub(1);
             let location = editor.doc_mut().char_loc();
             if y < editor.doc().len_lines() {
-                editor.doc_mut().goto_y(y);
+                editor.doc_mut().move_to_y(y);
                 editor.doc_mut().move_home();
                 if let Err(err) = editor.enter() {
                     editor.feedback = Feedback::Error(err.to_string());
@@ -998,18 +1031,18 @@ impl LuaUserData for Editor {
                     editor.feedback = Feedback::Error(err.to_string());
                 }
             }
-            editor.doc_mut().goto(&location);
+            editor.doc_mut().move_to(&location);
             update_highlighter(editor);
             Ok(())
         });
         methods.add_method_mut("remove_line_at", |_, editor, y: usize| {
             let y = y.saturating_sub(1);
             let location = editor.doc_mut().char_loc();
-            editor.doc_mut().goto_y(y);
+            editor.doc_mut().move_to_y(y);
             if let Err(err) = editor.delete_line() {
                 editor.feedback = Feedback::Error(err.to_string());
             }
-            editor.doc_mut().goto(&location);
+            editor.doc_mut().move_to(&location);
             update_highlighter(editor);
             Ok(())
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -946,6 +946,12 @@ impl LuaUserData for Editor {
             }
             Ok(())
         });
+        methods.add_method_mut("paste", |_, editor, ()| {
+            if let Err(err) = editor.paste() {
+                editor.feedback = Feedback::Error(err.to_string());
+            }
+            Ok(())
+        });
         methods.add_method_mut("move_home", |_, editor, ()| {
             editor.doc_mut().move_home();
             update_highlighter(editor);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -524,7 +524,7 @@ impl Editor {
 
     /// Copy the selected text
     pub fn copy(&mut self) -> Result<()> {
-        let selected_text = self.doc().selection_text().into_owned();
+        let selected_text = self.doc().selection_text();
         self.terminal.copy(&selected_text)
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -356,7 +356,8 @@ impl Editor {
                     for c in text.chars() {
                         let is_selected = self.doc().is_loc_selected(Loc { y: idx, x: x_pos });
                         if is_selected {
-                            write!(self.terminal.stdout, "{}", Bg(self.config.colors.borrow().editor_fg.to_color()?))?;
+                            write!(self.terminal.stdout, "{}", Bg(self.config.colors.borrow().selection_bg.to_color()?))?;
+                            write!(self.terminal.stdout, "{}", Fg(self.config.colors.borrow().selection_fg.to_color()?))?;
                         } else {
                             write!(self.terminal.stdout, "{}", Bg(self.config.colors.borrow().editor_bg.to_color()?))?;
                         }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -252,8 +252,8 @@ impl Editor {
         Ok(None)
     }
 
+    /// Append any missed lines to the syntax highlighter
     pub fn update_highlighter(&mut self) -> Result<()> {
-        // Append any missed lines to the syntax highlighter
         if self.active {
             let actual = self.doc.get(self.ptr).and_then(|d| Some(d.loaded_to)).unwrap_or(0);
             let percieved = self.highlighter().line_ref.len();
@@ -370,6 +370,7 @@ impl Editor {
         Ok(())
     }
 
+    /// Put together the contents of a tab
     fn render_document_tab_header(&self, document: &Document) -> String {
         let file_name = document.file_name.clone().unwrap_or_else(|| "[No Name]".to_string());
         let modified = if document.modified { "[+]" } else { "" };

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -526,6 +526,18 @@ impl Editor {
         self.terminal.copy(&selected_text)
     }
 
+    /// Paste the selected text
+    pub fn paste(&mut self) -> Result<()> {
+        let clip = self.terminal.paste();
+        for ch in clip.unwrap().chars() {
+            if let Err(err) = self.character(ch) {
+                self.feedback = Feedback::Error(err.to_string());
+            }
+        }
+        self.update_highlighter()?;
+        Ok(())
+    }
+
     /// Move the cursor up
     pub fn select_up(&mut self) {
         self.doc_mut().select_up();

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -34,7 +34,7 @@ impl Editor {
             MouseEventKind::Down(MouseButton::Left) => {
                 match self.find_mouse_location(event) {
                     MouseLocation::File(loc) => {
-                        self.doc_mut().goto(&loc);
+                        self.doc_mut().move_to(&loc);
                     },
                     MouseLocation::Tabs(i) => {
                         self.ptr = i;
@@ -42,13 +42,21 @@ impl Editor {
                     MouseLocation::Out => (),
                 }
             },
+            MouseEventKind::Drag(MouseButton::Left) => {
+                match self.find_mouse_location(event) {
+                    MouseLocation::File(loc) => {
+                        self.doc_mut().select_to(&loc);
+                    },
+                    MouseLocation::Tabs(_) | MouseLocation::Out => (),
+                }
+            }
             MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => {
                 match self.find_mouse_location(event) {
                     MouseLocation::File(_) => {
                         if event.kind == MouseEventKind::ScrollDown {
-                            self.doc_mut().move_down();
+                            self.doc_mut().scroll_down();
                         } else {
-                            self.doc_mut().move_up();
+                            self.doc_mut().scroll_up();
                         }
                     },
                     _ => (),

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -62,6 +62,12 @@ impl Editor {
                     _ => (),
                 }
             }
+            MouseEventKind::ScrollLeft => {
+                self.doc_mut().move_left();
+            }
+            MouseEventKind::ScrollRight => {
+                self.doc_mut().move_right();
+            }
             _ => (),
         }
     }

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -33,7 +33,8 @@ impl Editor {
         match event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 match self.find_mouse_location(event) {
-                    MouseLocation::File(loc) => {
+                    MouseLocation::File(mut loc) => {
+                        loc.x = self.doc_mut().character_idx(&loc);
                         self.doc_mut().move_to(&loc);
                     },
                     MouseLocation::Tabs(i) => {
@@ -44,7 +45,8 @@ impl Editor {
             },
             MouseEventKind::Drag(MouseButton::Left) => {
                 match self.find_mouse_location(event) {
-                    MouseLocation::File(loc) => {
+                    MouseLocation::File(mut loc) => {
+                        loc.x = self.doc_mut().character_idx(&loc);
                         self.doc_mut().select_to(&loc);
                     },
                     MouseLocation::Tabs(_) | MouseLocation::Out => (),

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ quick_error! {
             from()
             display("Error in lua: {}", err)
         }
+        Clipboard {
+            display("Error using clipboard")
+        }
         None
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,8 +20,11 @@ pub const HELP_TEXT: &str = "
    Ctrl + O:   Open            
    Ctrl + Q:   Quit            
    Ctrl + S:   Save            
-   Ctrl + W:   Save as         
-   Ctrl + A:   Save all        
+   Alt  + W:   Save as         
+   Alt  + A:   Save all        
+   Ctrl + A:   Select All      
+   Ctrl + C:   Copy            
+   Ctrl + V:   Paste           
    Ctrl + Z:   Undo            
    Ctrl + Y:   Redo            
    Ctrl + F:   Find            

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -126,6 +126,7 @@ impl Terminal {
 
     /// Restore terminal back to state before the editor was started
     pub fn end(&mut self) -> Result<()> {
+        self.show_cursor();
         terminal::disable_raw_mode()?;
         execute!(self.stdout, LeaveAlternateScreen, EnableLineWrap)?;
         if self.config.borrow().mouse_enabled {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,6 +11,7 @@ use kaolinite::utils::Size;
 use std::cell::RefCell;
 use std::io::{stdout, Stdout, Write};
 use std::rc::Rc;
+use base64::prelude::*;
 
 /// Constant that shows the help message
 pub const HELP_TEXT: &str = "
@@ -157,6 +158,15 @@ impl Terminal {
 
     pub fn flush(&mut self) -> Result<()> {
         self.stdout.flush()?;
+        Ok(())
+    }
+    
+    pub fn copy(&mut self, text: &str) -> Result<()> {
+        write!(
+            self.stdout,
+            "\x1b]52;c;{}\x1b\\",
+            BASE64_STANDARD.encode(text)
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR adds:
* Selection with mouse
* Selection with arrow keys
* Select all
* Copy the text inside selection using osc52

To make selection with mouse work with scroll, I needed to make scroll not move the cursor, and to do that, I made a substantial change to the cursor. The cursor now stores its position in file instead of in screen, so you can scroll in a way that put cursor out of screen (you will get focus back to the cursor if you type something). With the changes made in the cursor and scroll, ox now behaves more similar to other editors.

This PR does not implement any feature related to editing the selection, for example deleting it or replacing it by typing. The reason is that it requires a massive amount of change to the undo/event system, which I think it doesn't worth it and I have different ideas about implementing undo. So I differed that part to a later PR.

My idea about undo is that the current event system which requires each event to become reversible will become increasingly more complex over time (currently the challenge is selection, but imagine multi cursor, automatic refactors from compilers and lsp, ...). Instead, we can take a snapshot from the editor state (file content, cursor position, selection, maybe offset, ...) frequently (for example at each event, or 1 second after idle, or something like that, we can look at what other editors do) and at undo we can easily switch between those snapshots. Thankfully, the `ropey` library supports O(1) clone for rope so we don't have much challenge for storing the snapshots efficiently. I think this makes undo less error prone and reduces its overhead on later features. If you are interested in that, I can do it in another PR.