### PR TITLE
chore: Replace quick_error with error_set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dyn-fmt"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c992f591dfce792a9bc2d1880ab67ffd4acc04551f8e551ca3b6233efb322f00"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +147,28 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error_set"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8a70e1c5e3557e22af5af1e78f546303c9953638e60aee2c547322076cfabf"
+dependencies = [
+ "error_set_impl",
+]
+
+[[package]]
+name = "error_set_impl"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f8c9888cc6d3349076683c776fc48d3b0b8685aa2ca05107cfa1df72445157"
+dependencies = [
+ "dyn-fmt",
+ "indices",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -164,6 +204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
+name = "indices"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e125c680c3871dc195cfd3ff94a877a78f31d5e9c1a3a62cce82689ece14bf7"
+
+[[package]]
 name = "jargon-args"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +219,7 @@ checksum = "b9d38e5712e29fb0c2caeb33b1803c8feade6e3380c7a92788fb219999b2849e"
 name = "kaolinite"
 version = "0.9.5"
 dependencies = [
- "quick-error",
+ "error_set",
  "rand",
  "regex",
  "ropey",
@@ -202,6 +248,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -311,10 +363,10 @@ dependencies = [
  "alinio",
  "base64",
  "crossterm",
+ "error_set",
  "jargon-args",
  "kaolinite",
  "mlua",
- "quick-error",
  "shellexpand",
  "synoptic",
 ]
@@ -365,12 +417,6 @@ checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ crossterm = "0.28.1"
 jargon-args = "0.2.7"
 kaolinite = { path = "./kaolinite" }
 mlua = { version = "0.9.9", features = ["lua54", "vendored"] }
-quick-error = "2.0.1"
+error_set = "0.6"
 shellexpand = "3.1.0"
 synoptic = "2"

--- a/kaolinite/Cargo.toml
+++ b/kaolinite/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["unicode", "text-processing"]
 categories = ["text-processing"]
 
 [dependencies]
-quick-error = "2.0.1"
+error_set = "0.6"
 regex = "1.10.6"
 ropey = "1.6.1"
 unicode-width = "0.2"

--- a/kaolinite/README.md
+++ b/kaolinite/README.md
@@ -60,7 +60,7 @@ This software uses the following open source crates:
 - [unicode-width](https://github.com/unicode-rs/unicode-width)
 - [regex](https://github.com/rust-lang/regex)
 - [ropey](https://github.com/cessen/ropey)
-- [quick_error](https://github.com/tailhook/quick-error)
+- [error_set](https://github.com/mcmah309/error_set)
 
 ## License
 

--- a/kaolinite/src/event.rs
+++ b/kaolinite/src/event.rs
@@ -1,6 +1,6 @@
 /// event.rs - manages editing events and provides tools for error handling
 use crate::{document::Cursor, utils::Loc, Document};
-use quick_error::quick_error;
+use error_set::error_set;
 use ropey::Rope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,24 +75,17 @@ pub enum Status {
 /// Easy result type for unified error handling
 pub type Result<T> = std::result::Result<T, Error>;
 
-quick_error! {
+error_set! {
     /// Error enum for handling all possible errors
-    #[derive(Debug)]
-    pub enum Error {
-        Io(err: std::io::Error) {
-            from()
-            display("I/O error: {}", err)
-            source(err)
-        }
-        Rope(err: ropey::Error) {
-            from()
-            display("Rope error: {}", err)
-            source(err)
-        }
-        NoFileName
-        OutOfRange
+    Error = {
+        #[display("I/O error: {0}")]
+        Io(std::io::Error),
+        #[display("Rope error: {0}")]
+        Rope(ropey::Error),
+        NoFileName,
+        OutOfRange,
         ReadOnlyFile
-    }
+    };
 }
 
 /// For managing events for purposes of undo and redo

--- a/src/config/colors.rs
+++ b/src/config/colors.rs
@@ -343,7 +343,9 @@ impl Color {
         // Ensure the hex code is exactly 6 characters long
         if hex.len() != 6 {
             let msg = "Invalid hex code used in configuration file - ensure they are of length 6";
-            return Err(OxError::Config(msg.to_string()));
+            return Err(OxError::Config {
+                msg: msg.to_string(),
+            });
         }
 
         // Parse the hex string into the RGB components
@@ -354,7 +356,9 @@ impl Color {
                 tri.push(val);
             } else {
                 let msg = "Invalid hex code used in configuration file - ensure all digits are between 0 and F";
-                return Err(OxError::Config(msg.to_string()));
+                return Err(OxError::Config {
+                    msg: msg.to_string(),
+                });
             }
         }
         Ok((tri[0], tri[1], tri[2]))

--- a/src/config/highlighting.rs
+++ b/src/config/highlighting.rs
@@ -23,9 +23,9 @@ impl SyntaxHighlighting {
         if let Some(col) = self.theme.get(name) {
             col.to_color()
         } else {
-            Err(OxError::Config(format!(
-                "{name} has not been given a colour in the theme",
-            )))
+            Err(OxError::Config {
+                msg: format!("{name} has not been given a colour in the theme",),
+            })
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -184,7 +184,9 @@ impl Config {
         if user_provided_config {
             Ok(())
         } else {
-            Err(OxError::Config("Not Found".to_string()))
+            Err(OxError::Config {
+                msg: "Not Found".to_string(),
+            })
         }
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -317,7 +317,7 @@ impl Editor {
         // Display any warnings if the user configuration couldn't be found
         match result {
             Ok(()) => (),
-            Err(OxError::Config(msg)) => {
+            Err(OxError::Config { msg }) => {
                 if msg == "Not Found" {
                     let warn =
                         "No configuration file found, using default configuration".to_string();

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -135,9 +135,9 @@ impl Editor {
     pub fn open(&mut self, file_name: &str) -> Result<()> {
         if let Some(idx) = self.already_open(&get_absolute_path(file_name).unwrap_or_default()) {
             self.ptr = idx;
-            return Err(OxError::AlreadyOpen(
-                get_file_name(file_name).unwrap_or_default(),
-            ));
+            return Err(OxError::AlreadyOpen {
+                file: get_file_name(file_name).unwrap_or_default(),
+            });
         }
         let mut size = size()?;
         size.h = size.h.saturating_sub(1 + self.push_down);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 /// Error handling utilities
-use kaolinite::event::Error as KError;
 use error_set::error_set;
+use kaolinite::event::Error as KError;
 
 error_set! {
     OxError = {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,39 +1,30 @@
 /// Error handling utilities
 use kaolinite::event::Error as KError;
-use quick_error::quick_error;
+use error_set::error_set;
 
-quick_error! {
-    /// Error type used throughout the editor
-    #[derive(Debug)]
-    pub enum OxError {
-        Render(err: std::io::Error) {
-            from()
-            display("Error in I/O: {}", err)
-        }
-        Kaolinite(err: KError) {
-            from()
-            display("{}", {
-                match err {
-                    KError::NoFileName => "This document has no file name, please use 'save as' instead".to_string(),
-                    KError::OutOfRange => "Requested operation is out of range".to_string(),
-                    KError::ReadOnlyFile => "This file is read only and can't be saved or edited".to_string(),
-                    KError::Rope(rerr) => format!("Backend had an issue processing text: {rerr}"),
-                    KError::Io(ioerr) => format!("I/O Error: {ioerr}"),
-                }
-            })
-        }
-        Config(msg: String) {
-            display("Error in config file: {}", msg)
-        }
-        Lua(err: mlua::prelude::LuaError) {
-            from()
-            display("Error in lua: {}", err)
-        }
-        Cancelled {
-            display("Operation Cancelled")
-        }
-        None
-    }
+error_set! {
+    OxError = {
+        #[display("Error in I/O: {0}")]
+        Render(std::io::Error),
+        #[display("{}",
+            match source {
+                KError::NoFileName => "This document has no file name, please use 'save as' instead".to_string(),
+                KError::OutOfRange => "Requested operation is out of range".to_string(),
+                KError::ReadOnlyFile => "This file is read only and can't be saved or edited".to_string(),
+                KError::Rope(rerr) => format!("Backend had an issue processing text: {rerr}"),
+                KError::Io(ioerr) => format!("I/O Error: {ioerr}"),
+            }
+        )]
+        Kaolinite(KError),
+        #[display("Error in config file: {}", msg)]
+        Config {
+            msg: String
+        },
+        #[display("Error in lua: {0}")]
+        Lua(mlua::prelude::LuaError),
+        #[display("Operation Cancelled")]
+        Cancelled
+    };
 }
 
 /// Easy syntax sugar to have functions return the custom error type

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ fn handle_file_opening(editor: &Rc<RefCell<Editor>>, result: Result<()>, name: &
     }
     match result {
         Ok(()) => (),
-        Err(OxError::AlreadyOpen(_)) => {
+        Err(OxError::AlreadyOpen { .. }) => {
             let len = editor.borrow().files.len().saturating_sub(1);
             editor.borrow_mut().ptr = len;
         }


### PR DESCRIPTION
I was looking at your code and saw that you used `quick_error`, which I hadn't heard of. I've been working on another error definition approach [error_set](https://github.com/mcmah309/error_set) and I wanted to see if there were any features in `quick_error` it was missing or I could get inspiration from. So I replaced `quick_error` with `error_set` to see. Looks like it covers all the features.

Feel free to not merge and close this PR if you prefer the ergonomics of `quick_error`.