### PR TITLE
Add the super modifier.

### DIFF
--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -79,6 +79,9 @@ pub fn key_to_string(modifiers: KMod, key: KCode) -> String {
     if modifiers.contains(KMod::SHIFT) {
         result += "shift_";
     }
+    if modifiers.contains(KMod::SUPER) {
+        result += "super_";
+    }
     result += &match key {
         KCode::Char('\\') => "\\\\".to_string(),
         KCode::Char('"') => "\\\"".to_string(),


### PR DESCRIPTION
I added support for the "super" (command ⌘ / windows) key modifier in keyboard shortcuts. I put it at the end of the chain so that modifiers are formatted as: `ctrl_alt_shift_super_{key}`. It is the way that macOS does it for its native display of keyboard shortcuts.