### PR TITLE
Allow to use key shortcut to operate multi-cursors

### DIFF
--- a/config/.oxrc
+++ b/config/.oxrc
@@ -25,6 +25,18 @@ event_mapping = {
     ["ctrl_right"] = function() 
         editor:move_next_word() 
     end,
+    ["ctrl_shift_up"] = function() 
+        editor:add_cursor_above() 
+    end,
+    ["ctrl_shift_down"] = function() 
+        editor:add_cursor_below() 
+    end,
+    ["alt_shift_up"] = function() 
+        editor:delete_cursor_below() 
+    end,
+    ["alt_shift_down"] = function() 
+        editor:delete_cursor_above() 
+    end,
     ["home"] = function() 
         editor:move_home() 
     end,
@@ -59,6 +71,7 @@ event_mapping = {
     end,
     ["esc"] = function()
         editor:cancel_selection()
+        editor:cancel_multi_cursors()
     end,
     ["shift_home"] = function()
         local n_moves = editor.cursor.x

--- a/kaolinite/tests/test.rs
+++ b/kaolinite/tests/test.rs
@@ -1045,6 +1045,30 @@ fn fuzz() {
                 }
                 23 => doc.undo(),
                 24 => doc.redo(),
+                25 => {
+                    doc.add_cursor_above();
+                    Ok(())
+                }
+                26 => {
+                    doc.add_cursor_below();
+                    Ok(())
+                }
+                27 => {
+                    doc.delete_cursor_above();
+                    Ok(())
+                }
+                28 => {
+                    doc.delete_cursor_below();
+                    Ok(())
+                }
+                29 => {
+                    doc.delete_cursor_below();
+                    Ok(())
+                }
+                30 => {
+                    doc.delete_cursor_below();
+                    Ok(())
+                }
                 _ => Ok(()),
             };
             println!("{} | {}", doc.loc().x, doc.char_ptr);

--- a/plugins/quickcomment.lua
+++ b/plugins/quickcomment.lua
@@ -102,8 +102,8 @@ function quickcomment:comment_start()
         comment_start = "#"
     elseif editor.document_type == "Clojure" then
         comment_start = ";"
-    elseif editor.document_type == "Zsh" then
-        comment_start = "#"
+    elseif editor.document_type == "Batch" then
+        comment_start = "@REM"
     else
         comment_start = "//"
     end

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -274,6 +274,30 @@ impl LuaUserData for Editor {
             }
             Ok(())
         });
+        methods.add_method_mut("add_cursor_above", |_, editor, ()| {
+            if let Some(doc) = editor.try_doc_mut() {
+                doc.add_cursor_above();
+            }
+            Ok(())
+        });
+        methods.add_method_mut("add_cursor_below", |_, editor, ()| {
+            if let Some(doc) = editor.try_doc_mut() {
+                doc.add_cursor_below();
+            }
+            Ok(())
+        });
+        methods.add_method_mut("delete_cursor_above", |_, editor, ()| {
+            if let Some(doc) = editor.try_doc_mut() {
+                doc.delete_cursor_above();
+            }
+            Ok(())
+        });
+        methods.add_method_mut("delete_cursor_below", |_, editor, ()| {
+            if let Some(doc) = editor.try_doc_mut() {
+                doc.delete_cursor_below();
+            }
+            Ok(())
+        });
         methods.add_method_mut("move_previous_word", |_, editor, ()| {
             editor.prev_word();
             editor.update_highlighter();
@@ -347,6 +371,12 @@ impl LuaUserData for Editor {
         methods.add_method_mut("cancel_selection", |_, editor, ()| {
             if let Some(doc) = editor.try_doc_mut() {
                 doc.cancel_selection();
+            }
+            Ok(())
+        });
+        methods.add_method_mut("cancel_multi_cursors", |_, editor, ()| {
+            if let Some(doc) = editor.try_doc_mut() {
+                doc.cancel_multi_cursors();
             }
             Ok(())
         });


### PR DESCRIPTION
Allow to use key shortcut to operate multi-cursors. You can use:
    ctrl_shift_up:       add_cursor_above
    ctrl_shift_down: add_cursor_below
    alt_shift_up:        delete_cursor_above
    alt_shift_down:   delete_cursor_above
If you merge this PR, I can update corresponding description for multi cursors in wiki.

Besides, I just recommend code should set "ctrl_home" and "ctrl_end" to go top and bottom of the buffer and I can use "ctrl_up" and "ctrl_down" to add cursor above/below. And I believe "ctrl_home" and "ctrl_end" are more logical.

What's more, remove 2 bugs:
    1. Removed the duplicate Zsh check in quickcomment.lua and added a check for Batch.
    2. Removed the multi-cursors bug when anyone of them is at the top or end. Reproduce steps:
        a. Create multiple cursors and one of them is at the top or end of the doc.
        b. Move cursor up or down.
        c. Type sth.